### PR TITLE
Fix processing multiple ini files by resetting the current section at…

### DIFF
--- a/node-ini.js
+++ b/node-ini.js
@@ -23,7 +23,6 @@ var INI = function(){
       };
 
   self.encoding = 'utf-8'
-  self.curSection = {}
 
   var addParam = function(pType, cfg, match){
     switch(self.curSection.type){
@@ -95,6 +94,7 @@ var INI = function(){
   var parse = function(data){
     var lines = data.split(/\r\n|\r|\n/)
       , cfg = {};
+    self.curSection = {}
 
     lines.forEach(function(line){
       // Check for comments


### PR DESCRIPTION
… the beginning of the parse.

I have a process which loops over a folder structure which contains VB6 project files (which are essentially ini files). The process worked fine with a single file, when when I came to test the process with multiple files I ended up with a crash. I have made a small tweak to reset the section with each new parse.